### PR TITLE
Fix to parse inline and display math correctly

### DIFF
--- a/src/latex-to-ast.ts
+++ b/src/latex-to-ast.ts
@@ -302,8 +302,8 @@ export const parse = (text: string): any => {
               node.location.start.offset,
               node.location.end.offset
             ),
-            type: ASTNodeTypes.CodeBlock,
-            children: node.content
+            value: latexParser.stringify(node.content),
+            type: ASTNodeTypes.CodeBlock
           });
           break;
         case "inlineMath":
@@ -326,8 +326,8 @@ export const parse = (text: string): any => {
               node.location.start.offset,
               node.location.end.offset
             ),
-            type: ASTNodeTypes.Code,
-            children: node.content
+            value: latexParser.stringify(node.content),
+            type: ASTNodeTypes.Code
           });
           break;
         case "verb":

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -21,6 +21,20 @@ describe("TxtNode AST", () => {
         `;
     ASTTester.test(parse(code));
   });
+  test("Parse display math", async () => {
+    const code = `\\begin{equation}
+          x^2 - 6x + 1 = 0
+        \\end{equation}
+        `;
+    ASTTester.test(parse(code));
+  });
+  test("Parse inline math", async () => {
+    const code = `\\begin{document}
+          $x^2 = 4$
+        \\end{document}
+        `;
+    ASTTester.test(parse(code));
+  });
 });
 
 describe("Fixing document", () => {


### PR DESCRIPTION
close #33 

簡単に修正できそうだったのでやってみました．
`latexParser.stringify`にどうもバグがあるようで，superscript（`^`）を含む数式をうまく文字列化できないようです．何か良い解決方法があれば修正します．